### PR TITLE
Add printing annotated version of a file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2019/10/07 20:31:24 by gloras-t          #+#    #+#              #
-#    Updated: 2020/06/07 09:27:06 by dtimeon          ###   ########.fr        #
+#    Updated: 2020/06/08 13:47:06 by dtimeon          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -60,7 +60,8 @@ OBJ_ASM		=	$(addprefix $(OBJ_ASM_DIR)/, printer.o \
 				parsing_binary_header.o \
 				translating_utils.o \
 				parsing_binary_code.o \
-				parsing_binary_args.o)
+				parsing_binary_args.o \
+				printing_annotated_file.o)
 
 INCLUDES	=	includes
 LIBFT 		=	$(INCLUDES)/ft_printf

--- a/includes/asm.h
+++ b/includes/asm.h
@@ -6,7 +6,7 @@
 /*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2019/11/11 20:56:19 by gloras-t          #+#    #+#             */
-/*   Updated: 2020/06/07 09:20:29 by dtimeon          ###   ########.fr       */
+/*   Updated: 2020/06/08 13:46:10 by dtimeon          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,6 +47,10 @@
 # define DIR_STR				"direct"
 # define IND_STR				"indirect"
 
+# define REG_SYM				"r"
+# define DIR_SYM				"%"
+# define IND_SYM				""
+
 # define TYPES_STRINGS			{ REG_STR, DIR_STR, IND_STR }
 
 # define TAB_LEN				4
@@ -74,11 +78,23 @@ typedef struct					s_arg
 	unsigned char				code;
 	int							value;
 	int							value_len;
+	char						*str_value;
 	unsigned char				size;
 	unsigned char				has_value_from_label;
 	char						*label_name;
 	size_t						label_name_len;
+	size_t						pos;
+	char						*sym;
 }								t_arg;
+
+typedef struct					s_label
+{
+	char						*name;
+	size_t						name_len;
+	struct s_line				*op_line;
+	struct s_label				*next;
+	size_t						pos;
+}								t_label;
 
 typedef struct					s_line
 {
@@ -89,7 +105,10 @@ typedef struct					s_line
 	size_t						pos;
 	unsigned short int			len;
 	unsigned char				has_label_in;
+	t_label						*label;
 	unsigned char				has_label_to_find;
+	size_t						op_pos;
+	unsigned char				arg_types_code;
 	struct s_line				*next;
 }								t_line;
 
@@ -100,14 +119,6 @@ typedef struct					s_error_data
 	char						*message;
 	unsigned char				is_needed_to_free_message;
 }								t_error_data;
-
-typedef struct					s_label
-{
-	char						*name;
-	size_t						name_len;
-	t_line						*op_line;
-	struct s_label				*next;
-}								t_label;
 
 typedef struct					s_file
 {
@@ -171,8 +182,11 @@ void							parse_asm_code(t_file *file);
 void							parse_labels(t_file *file, t_line **cur_line,
 											char **start_pos, char *label_name);
 
+unsigned short int				calc_op_size(t_line *line);
 void							parse_asm_op(t_file *file, t_line *cur_line,
 												char **start_pos);
+
+void							save_op_data(char **str, t_line *line);
 t_op							*get_op(char **str);
 
 void							assign_arg_as(unsigned char type, t_arg *arg,
@@ -190,8 +204,11 @@ unsigned char					is_comment_cmd(char *start_pos);
 
 void							translate_file(t_file *file, short int options);
 
+void							fill_arg_types_codes(t_line *line);
+char							*ft_strndup(const char *src, size_t n);
 size_t							to_big_endian(size_t le_num, unsigned int size);
 
+void							print_annotated_file(t_file *file);
 void							print_error(char *filename, char *message);
 void							print_usage(char *program_path);
 void							print_file_parsing_error(t_file *file);

--- a/src_asm/asm.c
+++ b/src_asm/asm.c
@@ -6,7 +6,7 @@
 /*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2019/11/11 20:55:42 by gloras-t          #+#    #+#             */
-/*   Updated: 2020/05/28 09:13:42 by dtimeon          ###   ########.fr       */
+/*   Updated: 2020/06/08 14:27:31 by dtimeon          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,8 @@ void			process_file(char *filename, short int options)
 		}
 		delete_file(&file);
 	}
-	close(fd);
+	if (fd >= 0)
+		close(fd);
 }
 
 int				main(int argc, char *argv[])

--- a/src_asm/file_translation.c
+++ b/src_asm/file_translation.c
@@ -6,7 +6,7 @@
 /*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/05/11 01:45:40 by dtimeon           #+#    #+#             */
-/*   Updated: 2020/05/11 02:38:52 by dtimeon          ###   ########.fr       */
+/*   Updated: 2020/06/08 13:45:26 by dtimeon          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,7 @@
 
 void			translate_file(t_file *file, short int options)
 {
-	// TODO: translates file line by line and saves or prints result
-	// according to options given
-	(void)file;
-	(void)options;
+	fill_arg_types_codes(file->first_code_line);
+	if (options & ANNOTATION_OPTION_CODE)
+		print_annotated_file(file);
 }

--- a/src_asm/freeing_memory.c
+++ b/src_asm/freeing_memory.c
@@ -6,7 +6,7 @@
 /*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/05/11 01:44:01 by dtimeon           #+#    #+#             */
-/*   Updated: 2020/06/07 09:12:50 by dtimeon          ###   ########.fr       */
+/*   Updated: 2020/06/08 13:58:19 by dtimeon          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,12 +16,21 @@
 void			delete_lines(t_file *file)
 {
 	t_line		*temp_line;
+	int			i;
 
 	while (file->first_line)
 	{
 		temp_line = file->first_line;
 		file->first_line = temp_line->next;
 		ft_strdel(&(temp_line->initial_str));
+		i = 0;
+		if (temp_line->op_data)
+			while (i < temp_line->op_data->number_of_args)
+			{
+				if (temp_line->args[i].str_value)
+					ft_strdel(&(temp_line->args[i].str_value));
+				i++;
+			}
 		ft_memdel((void**)&temp_line);
 	}
 }

--- a/src_asm/parsing_asm_arg.c
+++ b/src_asm/parsing_asm_arg.c
@@ -6,7 +6,7 @@
 /*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/05/28 09:52:03 by dtimeon           #+#    #+#             */
-/*   Updated: 2020/06/07 14:25:03 by dtimeon          ###   ########.fr       */
+/*   Updated: 2020/06/07 17:42:01 by dtimeon          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,22 +20,26 @@ void		assign_arg_as(unsigned char type, t_arg *arg,
 		arg->type = T_REG;
 		arg->code = REG_CODE;
 		arg->size = REG_CODE_SIZE;
+		arg->sym = REG_SYM;
 	}
 	else if (type == T_IND)
 	{
 		arg->type = T_IND;
 		arg->code = IND_CODE;
 		arg->size = IND_CODE_SIZE;
+		arg->sym = IND_SYM;
 	}
 	else if (type == T_DIR)
 	{
 		arg->type = T_DIR;
 		arg->code = DIR_CODE;
 		arg->size = (is_dir_ind ? DIR_AS_IND_CODE_SIZE : DIR_AS_DATA_CODE_SIZE);
+		arg->sym = DIR_SYM;
 	}
 	arg->has_value_from_label = FALSE;
 	arg->label_name = NULL;
 	arg->value = 0;
+	arg->str_value = NULL;
 }
 
 static void		save_label_arg_value(char **str, t_line *line, int i,
@@ -55,6 +59,7 @@ static void		save_label_arg_value(char **str, t_line *line, int i,
 			line->args[i].has_value_from_label = TRUE;
 			line->args[i].label_name = *str;
 			line->args[i].label_name_len = j;
+			line->args[i].str_value = ft_strndup(*str - 1, j + 1);
 			*str += j;
 		}
 		else
@@ -79,6 +84,7 @@ static void		save_arg_value(char **str, t_line *line, int i, t_file *file)
 	{
 		line->args[i].value_len = j;
 		line->args[i].value = ft_atoi(*str);
+		line->args[i].str_value = ft_strndup(*str, j);
 		*str += j;
 	}
 	else

--- a/src_asm/parsing_asm_code.c
+++ b/src_asm/parsing_asm_code.c
@@ -6,7 +6,7 @@
 /*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/05/24 08:57:24 by dtimeon           #+#    #+#             */
-/*   Updated: 2020/05/28 10:21:34 by dtimeon          ###   ########.fr       */
+/*   Updated: 2020/06/08 15:30:11 by dtimeon          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,6 +56,7 @@ void					parse_asm_code(t_file *file)
 	{
 		start_pos = find_first_non_space_char(cur_line->initial_str);
 		label_name = find_label(&start_pos, file, cur_line);
+		cur_line->pos = file->code_size;
 		if (label_name)
 			parse_labels(file, &cur_line, &start_pos, label_name);
 		if (!(file->error_data) && start_pos)

--- a/src_asm/parsing_asm_labels.c
+++ b/src_asm/parsing_asm_labels.c
@@ -6,14 +6,21 @@
 /*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/05/28 10:03:54 by dtimeon           #+#    #+#             */
-/*   Updated: 2020/05/28 10:07:54 by dtimeon          ###   ########.fr       */
+/*   Updated: 2020/06/08 15:28:26 by dtimeon          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "asm.h"
 
+static void	save_label(t_line *line, t_label *label, size_t code_pos)
+{
+	line->has_label_in = TRUE;
+	line->pos = code_pos;
+	line->label = label;
+}
+
 static char	*find_next_op_str(t_file *file, t_line **cur_line,
-								t_label *first_label)
+								t_label *first_label, size_t code_pos)
 {
 	t_label	*temp_label;
 	char	*start_pos;
@@ -32,9 +39,9 @@ static char	*find_next_op_str(t_file *file, t_line **cur_line,
 			if (*start_pos &&
 				(new_label_name = find_label(&start_pos, file, *cur_line)))
 			{
-				(*cur_line)->has_label_in = TRUE;
 				temp_label->next = init_label(new_label_name, file->filename);
 				temp_label = temp_label->next;
+				save_label(*cur_line, temp_label, code_pos);
 			}
 			op_pos = find_first_non_space_char(start_pos);
 		}
@@ -75,20 +82,20 @@ void			parse_labels(t_file *file, t_line **cur_line, char **start_pos,
 {
 	t_label		*first_label;
 	char		*op_pos;
+	t_line		*first_label_line;
 
 	first_label = init_label(label_name, file->filename);
-	(*cur_line)->has_label_in = TRUE;
+	first_label_line = *cur_line;
 	op_pos = find_first_non_space_char(*start_pos);
 	if (!op_pos && (*cur_line)->next != file->last_line)
-		op_pos =find_next_op_str(file, cur_line, first_label);
+		op_pos =find_next_op_str(file, cur_line, first_label, (*cur_line)->pos);
 	*start_pos = op_pos;
 	if (op_pos)
-	{
 		first_label->op_line = *cur_line;
-		if (first_label->next)
-			save_op_line_to_labels(first_label);
-		save_labels_to_file(first_label, file);
-	}
 	else
-		delete_labels(&first_label);
+		first_label->op_line = first_label_line;
+	if (first_label->next)
+		save_op_line_to_labels(first_label);
+	save_label(first_label_line, first_label, first_label_line->pos);
+	save_labels_to_file(first_label, file);	
 }

--- a/src_asm/parsing_asm_op.c
+++ b/src_asm/parsing_asm_op.c
@@ -6,7 +6,7 @@
 /*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/05/28 09:40:26 by dtimeon           #+#    #+#             */
-/*   Updated: 2020/05/29 13:38:39 by dtimeon          ###   ########.fr       */
+/*   Updated: 2020/06/08 11:47:31 by dtimeon          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,7 +50,7 @@ static void					check_sep_symbol(t_file *file, t_line *line,
 		(*str)++;
 }
 
-static unsigned short int	calc_op_size(t_line *line)
+unsigned short int			calc_op_size(t_line *line)
 {
 	unsigned short int		len;
 	int						i;
@@ -78,7 +78,7 @@ void						parse_asm_op(t_file *file, t_line *cur_line,
 {
 	int						i;
 
-	cur_line->op_data = get_op(start_pos);
+	save_op_data(start_pos, cur_line);
 	if (!(cur_line->op_data))
 		fill_error(file, cur_line, *start_pos - cur_line->initial_str,
 					"This is not valid label or valid operation, nor comment");

--- a/src_asm/parsing_asm_op_finding_op.c
+++ b/src_asm/parsing_asm_op_finding_op.c
@@ -6,7 +6,7 @@
 /*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/05/28 10:00:33 by dtimeon           #+#    #+#             */
-/*   Updated: 2020/05/29 14:48:24 by dtimeon          ###   ########.fr       */
+/*   Updated: 2020/06/07 17:25:57 by dtimeon          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,4 +45,10 @@ t_op				*get_op(char **str)
 	extern t_op		g_op_tab[OP_NUM];
 
 	return(find_op(str, (t_op *)g_op_tab));
+}
+
+void				save_op_data(char **str, t_line *line)
+{
+	line->op_pos = *str - line->initial_str;
+	line->op_data = get_op(str);
 }

--- a/src_asm/parsing_binary_args.c
+++ b/src_asm/parsing_binary_args.c
@@ -6,7 +6,7 @@
 /*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/06/07 09:15:47 by dtimeon           #+#    #+#             */
-/*   Updated: 2020/06/07 09:23:05 by dtimeon          ###   ########.fr       */
+/*   Updated: 2020/06/08 13:28:56 by dtimeon          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,11 @@ static size_t	save_bin_arg(unsigned char *bin_data, t_arg *arg)
 		((unsigned char *)(&arg->value))[arg->size - j - 1] = bin_data[j];
 		j++;
 	}
+	if (arg->size == sizeof(char))
+		arg->value = (char)arg->value;
+	else if (arg->size == sizeof(short int))
+		arg->value = (short int)arg->value;
+	arg->str_value = ft_itoa(arg->value);
 	return (j);
 }
 

--- a/src_asm/parsing_binary_code.c
+++ b/src_asm/parsing_binary_code.c
@@ -6,7 +6,7 @@
 /*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/06/04 10:30:39 by dtimeon           #+#    #+#             */
-/*   Updated: 2020/06/07 10:38:40 by dtimeon          ###   ########.fr       */
+/*   Updated: 2020/06/08 12:16:40 by dtimeon          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,7 @@ static unsigned char	*parse_bin_arg_types(unsigned char *bin_data, t_line *line,
 			fill_error(file, NULL, pos, "Incorrect arguments types byte");
 		i++;
 	}
+	line->arg_types_code = *bin_data;
 	return (types);
 }
 
@@ -97,11 +98,17 @@ void					parse_binary_code(t_file *file)
 	size_t				bytes_parsed;
 
 	bytes_parsed = 0;
+	file->first_code_line = file->first_line;
 	while((bytes_parsed < file->code_size) && !(file->error_data))
 	{
 		bytes_parsed += parse_bin_op(file->champ_code + bytes_parsed,
 										bytes_parsed, file);
-		if (!(file->error_data) && (bytes_parsed < file->code_size))
+		if (!(file->error_data))
+		{
+			file->last_line->len = calc_op_size(file->last_line);
+			file->last_line->pos = bytes_parsed - file->last_line->len;
+		}
+		if (!(file->error_data) && (bytes_parsed <= file->code_size))
 		{
 			file->last_line->next = init_line();
 			if (!(file->last_line->next))

--- a/src_asm/printer.c
+++ b/src_asm/printer.c
@@ -6,7 +6,7 @@
 /*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2019/11/14 19:08:08 by dtimeon           #+#    #+#             */
-/*   Updated: 2020/06/07 09:28:49 by dtimeon          ###   ########.fr       */
+/*   Updated: 2020/06/08 14:21:15 by dtimeon          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,7 +38,7 @@ void		print_asm_parsing_error(t_file *file)
 	ssize_t	pos;
 	char	*message;
 
-	if (file->error_data->line)
+	if (file->error_data->line && file->error_data->line->initial_str)
 	{
 		line_num = file->error_data->line->num;
 		offset = ft_printf("     line %u: ", line_num);

--- a/src_asm/printing_annotated_file.c
+++ b/src_asm/printing_annotated_file.c
@@ -1,0 +1,107 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   printing_annotated_file.c                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2020/06/08 13:42:34 by dtimeon           #+#    #+#             */
+/*   Updated: 2020/06/08 15:18:40 by dtimeon          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "asm.h"
+
+static void		print_strwise_row(t_line *line)
+{
+	int 		i;
+
+	i = 0;
+	ft_printf("%-7zu(%hd):\t    %-10s", line->pos, line->len,
+				line->op_data->name);
+	while (i < line->op_data->number_of_args)
+	{
+		ft_printf("%s%-*s", line->args[i].sym,
+					18 - ft_strlen(line->args[i].sym), line->args[i].str_value);
+		i++;
+	}
+	ft_printf("\n");
+}
+
+static void		print_bytewise_row(t_line *line)
+{
+	int 		i;
+	int			j;
+	int			value;
+
+	ft_printf("%*s", 20, "");
+	ft_printf("%-4hhd", line->op_data->op_code);
+	if (line->op_data->has_arg_type_code)
+		ft_printf("%-6hhu", line->arg_types_code);
+	else
+		ft_printf("      ");
+	i = 0;
+	while (i < line->op_data->number_of_args)
+	{
+		j = 0;
+		value = to_big_endian(line->args[i].value, line->args[i].size);
+		while (j < line->args[i].size)
+		{
+			ft_printf("%-4hhu", ((unsigned char *)&value)[j]);
+			j++;
+		}
+		ft_printf("%-*s", 18 - (4 * line->args[i].size), "");
+		i++;
+	}
+	ft_printf("\n");
+}
+
+static void		print_typewise_row(t_line *line)
+{
+	int 		i;
+
+	ft_printf("%*s", 20, "");
+				ft_printf("%-4hhd", line->op_data->op_code);
+	if (line->op_data->has_arg_type_code)
+		ft_printf("%-6hhu", line->arg_types_code);
+	else
+		ft_printf("      ");
+	i = 0;
+	while (i < line->op_data->number_of_args)
+	{
+		ft_printf("%-18d", line->args[i].value);
+		i++;
+	}
+	ft_printf("\n");
+}
+
+static void		print_annotated_line(t_line *line)
+{
+
+	if (line->has_label_in)
+		ft_printf("%-10zu:%12s:\n", line->pos, line->label->name);
+	if (line->op_data)
+	{
+		print_strwise_row(line);
+		print_bytewise_row(line);
+		print_typewise_row(line);
+		ft_printf("\n");
+	}
+}
+
+void			print_annotated_file(t_file *file)
+{
+	t_line		*cur_line;
+
+	ft_printf("File: %s\n", file->filename);
+	ft_printf("Dumping annotated program on standard output\n");
+	ft_printf("Program size: %zu bytes\n", file->code_size);
+	ft_printf("Name: \"%s\"\n", file->champ_name);
+	ft_printf("Comment: \"%s\"\n\n", file->champ_comment);
+	cur_line = file->first_code_line;
+	while (cur_line != file->last_line)
+	{
+		print_annotated_line(cur_line);
+		cur_line = cur_line->next;
+	}
+}

--- a/src_asm/str_utils.c
+++ b/src_asm/str_utils.c
@@ -6,7 +6,7 @@
 /*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/05/11 01:46:09 by dtimeon           #+#    #+#             */
-/*   Updated: 2020/06/06 11:06:11 by dtimeon          ###   ########.fr       */
+/*   Updated: 2020/06/08 14:30:30 by dtimeon          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,9 +14,9 @@
 
 char			*find_first_non_space_char(char *str)
 {
-	while (*str && ft_isspace(*str))
+	while (str && *str && ft_isspace(*str))
 		str++;
-	if (*str)
+	if (str && *str)
 		return(str);
 	return(NULL);
 }
@@ -64,6 +64,7 @@ int				count_tabs(char *str)
 	int			num_of_tabs;
 
 	num_of_tabs = 0;
+	
 	while (*str)
 	{
 		if (*str == '\t')

--- a/src_asm/translating_utils.c
+++ b/src_asm/translating_utils.c
@@ -6,11 +6,48 @@
 /*   By: dtimeon <dtimeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/06/04 14:13:56 by dtimeon           #+#    #+#             */
-/*   Updated: 2020/06/04 14:14:15 by dtimeon          ###   ########.fr       */
+/*   Updated: 2020/06/08 13:46:07 by dtimeon          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "asm.h"
+
+void			fill_arg_types_codes(t_line *line)
+{
+	int			i;
+
+	while (line->next)
+	{
+		if (line->op_data && line->op_data->has_arg_type_code)
+		{
+			i = 0;
+			while (i < line->op_data->number_of_args)
+			{
+				line->arg_types_code |= (line->args[i].code << ((3 - i) * 2));
+				i++;
+			}
+		}
+		line = line->next;
+	}
+}
+
+char			*ft_strndup(const char *src, size_t n)
+{
+	char		*dest;
+	char		*temp_dest;
+
+	if (!(dest = (char *)malloc(sizeof(char) * (n + 1))))
+		return (NULL);
+	temp_dest = dest;
+	while (*src && n--)
+	{
+		*temp_dest = *src;
+		temp_dest++;
+		src++;
+	}
+	*temp_dest = '\0';
+	return (dest);
+}
 
 size_t			to_big_endian(size_t le_num, unsigned int size)
 {


### PR DESCRIPTION
The `-a` option is now working. Made a lot of changes to `parsing_*` functions -- needed to save more data for annotated output.
Also made bit of slight changes like adding a check that `fd` is bigger than -1 before closing a file.  